### PR TITLE
New Features

### DIFF
--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -11,7 +11,7 @@
 IB_DESIGNABLE
 @interface SSSnackbar : UIView
 /**
- *  The duration of time for which the snackbar should be shown on-screen. Changing this value only has effect before the snackbar is presented by sending it the show message.
+ *  The duration of time for which the snackbar should be shown on-screen, else 0 if the snackbar should be displayed indefinitely. Changing this value only has effect before the snackbar is presented by sending it the show message.
  */
 @property (assign, nonatomic) NSTimeInterval duration;
 /**
@@ -37,7 +37,7 @@ IB_DESIGNABLE
  *
  *  @param message        The message displayed on the snackbars's text label.
  *  @param actionText     The text displayed on the snackbar's action button.
- *  @param duration       The duration of time for which the snackbar should remain on the screen.
+ *  @param duration       The duration of time for which the snackbar should remain on the screen, else 0 if the snackbar should be displayed indefinitely.
  *  @param actionBlock    A block to be called when the user presses the action button.
  *  @param dismissalBlock A block to be called when the snackbar is removed from the screen by any means other than the user having pressed the action button. Can be nil.
  *
@@ -52,7 +52,7 @@ IB_DESIGNABLE
  *
  *  @param message        The message displayed on the snackbars's text label.
  *  @param actionText     The text displayed on the snackbar's action button.
- *  @param duration       The duration of time for which the snackbar should remain on the screen.
+ *  @param duration       The duration of time for which the snackbar should remain on the screen, else 0 if the snackbar should be displayed indefinitely.
  *  @param actionBlock    A block to be called when the user presses the action button.
  *  @param dismissalBlock A block to be called when the snackbar is removed from the screen by any means other than the user having pressed the action button. Can be nil.
  */

--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -70,6 +70,12 @@ IB_DESIGNABLE
  */
 - (void)show;
 /**
+ *  Presents the snackbar to the user for the configured duration of time.
+ * 
+ *  @param superview The view that the snackbar should be displayed within.
+ */
+- (void) showInView:(UIView *)superview;
+/**
  *  Removes the snackbar from the screen. Calls the snackbar's dismissal block if one exists, unless the snackbar has its isLongRunning property set to YES and it action button has already been pressed by the user. This message is shorthand for calling dismissAnimated with YES as the argument.
  */
 - (void)dismiss;

--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -79,4 +79,18 @@ IB_DESIGNABLE
  *  @param animated Determines whether the snackbars's removal from the screen is animated or not.
  */
 - (void)dismissAnimated:(BOOL)animated;
+/**
+ * Changes the color of the Snackbar's message text.
+ *
+ * @param color The new color that the message text should use.
+ */
+- (void) setMessageTextColor:(UIColor *)color;
+/**
+ * Changes the color of the Snackbar's action button text.
+ *
+ * @param color The new color that the action button text should use.
+ * @param state The button state that this text color should be applied to.
+ */
+- (void) setActionTextColor:(UIColor *)color
+                   forState:(UIControlState)state;
 @end

--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -19,6 +19,10 @@ IB_DESIGNABLE
  */
 @property (assign, nonatomic) BOOL actionIsLongRunning;
 /**
+ * If this value is set to YES, then the user can tap within the body of the Snackbar to dismiss it without executing it's associated action. Changing this value only has effect before the snackbar is presented by sending it the show message.
+ */
+@property (assign, nonatomic) BOOL canTapToDismiss;
+/**
  *  A block which is called when the user presses the action button on the snackbar.
  *
  *  Generally used to reverse some change made by the user which prompted the snackbar to be displayed.

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -74,6 +74,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
         
         _separator = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
         _separator.backgroundColor = [UIColor colorWithWhite:0.99 alpha:.1];
+        _separator.hidden = TRUE;
         _separator.translatesAutoresizingMaskIntoConstraints = NO;
         
         _tapToDismissRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
@@ -324,6 +325,17 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     
     [self addConstraints:constraints];
     [self layoutIfNeeded];
+}
+
+- (void) setMessageTextColor:(UIColor *)color
+{
+    [_messageLabel setTextColor:color];
+}
+
+- (void) setActionTextColor:(UIColor *)color
+                   forState:(UIControlState)state
+{
+    [_actionButton setTitleColor:color forState:state];
 }
 
 @end

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -113,7 +113,10 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     }
     
     UIView *superview = topController.view;
-    
+    [self showInView:superview];
+}
+
+- (void) showInView:(UIView *)superview {
     BOOL shouldReplaceExistingSnackbar = currentlyVisibleSnackbar != nil;
     
     if (shouldReplaceExistingSnackbar) {
@@ -156,13 +159,12 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 }
 
 - (void)replaceExistingSnackbar {
-    UIView *superview = [UIApplication sharedApplication].delegate.window.rootViewController.view;
     [currentlyVisibleSnackbar invalidateTimer];
     [currentlyVisibleSnackbar removeFromSuperview];
-    [superview addSubview:self];
-    [superview addConstraints:self.horizontalLayoutConstraints];
-    [superview addConstraints:self.visibleVerticalLayoutConstraints];
-    [superview layoutIfNeeded];
+    [self.superview addSubview:self];
+    [self.superview addConstraints:self.horizontalLayoutConstraints];
+    [self.superview addConstraints:self.visibleVerticalLayoutConstraints];
+    [self.superview layoutIfNeeded];
     [self setupContentLayout];
 }
 
@@ -289,13 +291,12 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                                                       views:NSDictionaryOfVariableBindings(self)];
         }
         else {
-            UIView * superView = [UIApplication sharedApplication].keyWindow.rootViewController.view;
             _horizontalLayoutConstraints = @[
 
                                              [NSLayoutConstraint constraintWithItem:self
                                                                           attribute:NSLayoutAttributeCenterX
                                                                           relatedBy:NSLayoutRelationEqual
-                                                                             toItem:superView
+                                                                             toItem:self.superview
                                                                           attribute:NSLayoutAttributeCenterX
                                                                          multiplier:1.0f
                                                                            constant:0.0f],

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -22,6 +22,8 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 @property (strong, nonatomic) NSArray *horizontalLayoutConstraints;
 
 @property (assign, nonatomic) BOOL actionBlockDispatched;
+
+@property (strong, nonatomic) UITapGestureRecognizer * tapToDismissRecognizer;
 @end
 
 @implementation SSSnackbar
@@ -73,6 +75,9 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
         _separator = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 0)];
         _separator.backgroundColor = [UIColor colorWithWhite:0.99 alpha:.1];
         _separator.translatesAutoresizingMaskIntoConstraints = NO;
+        
+        _tapToDismissRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                          action:@selector(dismiss)];
         
         [self addSubview:_messageLabel];
         [self addSubview:_actionButton];
@@ -143,6 +148,11 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                                                               repeats:NO];
     }
     
+    if (_canTapToDismiss)
+    {
+        [self addGestureRecognizer:_tapToDismissRecognizer];
+    }
+    
     currentlyVisibleSnackbar = self;
 }
 
@@ -167,6 +177,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 - (void)dismissAnimated:(BOOL)animated {
     [self invalidateTimer];
+    [self removeGestureRecognizer:_tapToDismissRecognizer];
     [self.superview removeConstraints:self.visibleVerticalLayoutConstraints];
     [self.superview addConstraints:self.hiddenVerticalLayoutConstraints];
     currentlyVisibleSnackbar = nil;
@@ -194,6 +205,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 - (IBAction)executeAction:(id)sender {
     [self invalidateTimer];
+    [self removeGestureRecognizer:_tapToDismissRecognizer];
     if (self.actionIsLongRunning) {
         UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
         indicator.translatesAutoresizingMaskIntoConstraints = NO;

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -283,12 +283,32 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 - (NSArray *)horizontalLayoutConstraints {
     if (!_horizontalLayoutConstraints) {
-        
-        _horizontalLayoutConstraints =
-        [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-5-[self]-(5)-|"
-                                                options:0
-                                                metrics:nil
-                                                  views:NSDictionaryOfVariableBindings(self)];
+        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+            _horizontalLayoutConstraints =
+            [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-5-[self]-(5)-|"
+                                                    options:0
+                                                    metrics:nil
+                                                      views:NSDictionaryOfVariableBindings(self)];
+        }
+        else {
+            UIView * superView = [UIApplication sharedApplication].keyWindow.rootViewController.view;
+            _horizontalLayoutConstraints = @[
+
+                                             [NSLayoutConstraint constraintWithItem:self
+                                                                          attribute:NSLayoutAttributeCenterX
+                                                                          relatedBy:NSLayoutRelationEqual
+                                                                             toItem:superView
+                                                                          attribute:NSLayoutAttributeCenterX
+                                                                         multiplier:1.0f constant:0.0f],
+                                             [NSLayoutConstraint constraintWithItem:self
+                                                                          attribute:NSLayoutAttributeWidth
+                                                                          relatedBy:NSLayoutRelationEqual
+                                                                             toItem:nil
+                                                                          attribute:NSLayoutAttributeNotAnAttribute
+                                                                         multiplier:1.0
+                                                                           constant:400.0]
+                                             ];
+        }
     }
     
     return _horizontalLayoutConstraints;

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -133,11 +133,16 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                          }
                          completion:nil];
     }
-    self.dismissalTimer = [NSTimer scheduledTimerWithTimeInterval:self.duration
-                                                           target:self
-                                                         selector:@selector(timeoutForDismissal:)
-                                                         userInfo:nil
-                                                          repeats:NO];
+    
+    if (self.duration > 0)
+    {
+        self.dismissalTimer = [NSTimer scheduledTimerWithTimeInterval:self.duration
+                                                               target:self
+                                                             selector:@selector(timeoutForDismissal:)
+                                                             userInfo:nil
+                                                              repeats:NO];
+    }
+    
     currentlyVisibleSnackbar = self;
 }
 

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -140,8 +140,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                          completion:nil];
     }
     
-    if (self.duration > 0)
-    {
+    if (self.duration > 0) {
         self.dismissalTimer = [NSTimer scheduledTimerWithTimeInterval:self.duration
                                                                target:self
                                                              selector:@selector(timeoutForDismissal:)
@@ -149,8 +148,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                                                               repeats:NO];
     }
     
-    if (_canTapToDismiss)
-    {
+    if (_canTapToDismiss) {
         [self addGestureRecognizer:_tapToDismissRecognizer];
     }
     
@@ -299,7 +297,8 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                                                                           relatedBy:NSLayoutRelationEqual
                                                                              toItem:superView
                                                                           attribute:NSLayoutAttributeCenterX
-                                                                         multiplier:1.0f constant:0.0f],
+                                                                         multiplier:1.0f
+                                                                           constant:0.0f],
                                              [NSLayoutConstraint constraintWithItem:self
                                                                           attribute:NSLayoutAttributeWidth
                                                                           relatedBy:NSLayoutRelationEqual
@@ -347,14 +346,12 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     [self layoutIfNeeded];
 }
 
-- (void) setMessageTextColor:(UIColor *)color
-{
+- (void) setMessageTextColor:(UIColor *)color {
     [_messageLabel setTextColor:color];
 }
 
 - (void) setActionTextColor:(UIColor *)color
-                   forState:(UIControlState)state
-{
+                   forState:(UIControlState)state {
     [_actionButton setTitleColor:color forState:state];
 }
 


### PR DESCRIPTION
New functions / properties:
- Snackbars can now be displayed indefinitely. Can be accomplished by setting the widget's timeout duration to 0 or less.
- Snackbar message and action button text color can now be customized. Can be accomplished via the new "setMessageTextColor:" and "setActionTextColor:forState" functions.
- Snackbars can now be tapped to dismiss. Disabled by default, can be enabled by setting the new "canTapToDismiss" property to TRUE / YES.
- Snackbars can now be added as a subview to a specific view. Can be accomplished via the new "showInView:" function.
- Hid the divider view. Snackbars no longer have visible dividers in the latest revision of Google's Material design guidelines.
