### PR TITLE
Ability for snackbar to show on top or bottom of view

### DIFF
--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -64,7 +64,7 @@ IB_DESIGNABLE
 /**
  *  Presents the snackbar to the user for the configured duration of time.
  */
-- (void)show;
+- (void)show:(BOOL)showTop;
 /**
  *  Removes the snackbar from the screen. Calls the snackbar's dismissal block if one exists, unless the snackbar has its isLongRunning property set to YES and it action button has already been pressed by the user. This message is shorthand for calling dismissAnimated with YES as the argument.
  */

--- a/Pod/Classes/SSSnackbar.h
+++ b/Pod/Classes/SSSnackbar.h
@@ -64,7 +64,8 @@ IB_DESIGNABLE
 /**
  *  Presents the snackbar to the user for the configured duration of time.
  */
-- (void)show:(BOOL)showTop;
+- (void)show;
+- (void)showTop;
 /**
  *  Removes the snackbar from the screen. Calls the snackbar's dismissal block if one exists, unless the snackbar has its isLongRunning property set to YES and it action button has already been pressed by the user. This message is shorthand for calling dismissAnimated with YES as the argument.
  */

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -42,7 +42,6 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
                                                       duration:duration
                                                    actionBlock:actionBlock
                                                 dismissalBlock:dismissalBlock];
-    
     return snackbar;
 }
 
@@ -91,12 +90,8 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
     }
-    return self;
-}
-
-- (void)viewDidLoad
-{
     self.showTop = NO;
+    return self;
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -110,7 +105,15 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     CGContextRestoreGState(ctx);
 }
 
-- (void)show:(BOOL)showTop {
+- (void)show {
+    [self showTopBottom:NO];
+}
+
+- (void)showTop {
+    [self showTopBottom:YES];
+}
+
+- (void)showTopBottom:(BOOL)showTop {
     
     if(showTop){
         self.visibleVerticalLayoutConstraintsPositionVisible = @"V:|-(5)-[self(44)]";

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -21,6 +21,11 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 @property (strong, nonatomic) NSArray *visibleVerticalLayoutConstraints;
 @property (strong, nonatomic) NSArray *horizontalLayoutConstraints;
 
+
+@property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionHidden;
+@property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionVisible;
+
+
 @property (assign, nonatomic) BOOL actionBlockDispatched;
 @end
 
@@ -100,7 +105,17 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     CGContextRestoreGState(ctx);
 }
 
-- (void)show {
+- (void)show:(BOOL)showTop {
+    
+    //shattar is if statement correct?
+    if(showTop){
+        self.visibleVerticalLayoutConstraintsPositionVisible = @"V:|-(5)-[self(44)]";
+        self.visibleVerticalLayoutConstraintsPositionHidden = @"V:|-(-50)-[self(44)]";
+    } else {
+        self.visibleVerticalLayoutConstraintsPositionVisible = @"V:[self(44)]-(5)-|";
+        self.visibleVerticalLayoutConstraintsPositionHidden = @"V:[self(44)]-(5)-|";
+    }
+    
     UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
     while (topController.presentedViewController) {
         topController = topController.presentedViewController;
@@ -240,8 +255,9 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 - (NSArray *)hiddenVerticalLayoutConstraints {
     if (!_hiddenVerticalLayoutConstraints) {
     
+        
         _hiddenVerticalLayoutConstraints =
-        [NSLayoutConstraint constraintsWithVisualFormat:@"V:[self(44)]-(-50)-|"
+        [NSLayoutConstraint constraintsWithVisualFormat:self.visibleVerticalLayoutConstraintsPositionHidden
                                                 options:0
                                                 metrics:nil
                                                   views:NSDictionaryOfVariableBindings(self)];
@@ -253,8 +269,9 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 - (NSArray *)visibleVerticalLayoutConstraints {
     if (!_visibleVerticalLayoutConstraints) {
         
+        
         _visibleVerticalLayoutConstraints =
-        [NSLayoutConstraint constraintsWithVisualFormat:@"V:[self(44)]-(5)-|"
+        [NSLayoutConstraint constraintsWithVisualFormat:self.visibleVerticalLayoutConstraintsPositionVisible
                                                 options:0
                                                 metrics:nil
                                                   views:NSDictionaryOfVariableBindings(self)];

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -21,10 +21,8 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 @property (strong, nonatomic) NSArray *visibleVerticalLayoutConstraints;
 @property (strong, nonatomic) NSArray *horizontalLayoutConstraints;
 
-
 @property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionHidden;
 @property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionVisible;
-
 
 @property (assign, nonatomic) BOOL actionBlockDispatched;
 @end
@@ -107,7 +105,6 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 - (void)show:(BOOL)showTop {
     
-    //shattar is if statement correct?
     if(showTop){
         self.visibleVerticalLayoutConstraintsPositionVisible = @"V:|-(5)-[self(44)]";
         self.visibleVerticalLayoutConstraintsPositionHidden = @"V:|-(-50)-[self(44)]";

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -12,6 +12,7 @@
 static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 @interface SSSnackbar ()
+
 @property (strong, nonatomic) UILabel *messageLabel;
 @property (strong, nonatomic) UIButton *actionButton;
 @property (strong, nonatomic) UIView *separator;
@@ -23,6 +24,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 @property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionHidden;
 @property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionVisible;
+@property (nonatomic) BOOL showTop;
 
 @property (assign, nonatomic) BOOL actionBlockDispatched;
 @end
@@ -90,6 +92,11 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
     if (self = [super initWithFrame:frame]) {
     }
     return self;
+}
+
+- (void)viewDidLoad
+{
+    self.showTop = NO;
 }
 
 - (void)drawRect:(CGRect)rect {

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -24,7 +24,6 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 
 @property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionHidden;
 @property (strong, nonatomic) NSString *visibleVerticalLayoutConstraintsPositionVisible;
-@property (nonatomic) BOOL showTop;
 
 @property (assign, nonatomic) BOOL actionBlockDispatched;
 @end
@@ -90,7 +89,6 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 - (instancetype)initWithFrame:(CGRect)frame {
     if (self = [super initWithFrame:frame]) {
     }
-    self.showTop = NO;
     return self;
 }
 

--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -114,7 +114,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
 - (void)showTopBottom:(BOOL)showTop {
     
     if(showTop){
-        self.visibleVerticalLayoutConstraintsPositionVisible = @"V:|-(5)-[self(44)]";
+        self.visibleVerticalLayoutConstraintsPositionVisible = @"V:|-(20)-[self(44)]";
         self.visibleVerticalLayoutConstraintsPositionHidden = @"V:|-(-50)-[self(44)]";
     } else {
         self.visibleVerticalLayoutConstraintsPositionVisible = @"V:[self(44)]-(5)-|";


### PR DESCRIPTION
Just added another method called showTop, show will still work the same and nothing will change. However now users who like using this for validation, no longer have to worry about their alert being hidden behind the keyboard.
