### PR TITLE
Use iOS 7 compatible method for creating bold system font

### DIFF
--- a/Pod/Classes/SSSnackbar.m
+++ b/Pod/Classes/SSSnackbar.m
@@ -62,7 +62,7 @@ static SSSnackbar *currentlyVisibleSnackbar = nil;
         
         _actionButton = [UIButton buttonWithType:UIButtonTypeSystem];
         _actionButton.translatesAutoresizingMaskIntoConstraints = NO;
-        _actionButton.titleLabel.font = [UIFont systemFontOfSize:14.0 weight:UIFontWeightBold];
+        _actionButton.titleLabel.font = [UIFont boldSystemFontOfSize:14.0];
         [_actionButton setTitle:actionText forState:UIControlStateNormal];
         [_actionButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
         [_actionButton sizeToFit];


### PR DESCRIPTION
`[UIFont systemFontOfSize:weight:];` is only available starting with iOS 8.2 so calling this method on older iOS versions causes a crash. This pull requests uses `[UIFont boldSystemFontOfSize:]` which has the same visual result as SSSnackbar uses `UIFontWeightBold` as a parameter when calling the incompatible method.
